### PR TITLE
browse: tweak the styling

### DIFF
--- a/static/browse/index.html
+++ b/static/browse/index.html
@@ -51,7 +51,7 @@
        </div>
 
        <div id="titlebar">
-	 <span id="home"><a href="/index.html">Home</a></span>
+	 <span id="home"><a href="/index.html"><abbr title="What is Chandra doing now? (text version)">WICDN?</abbr></a></span>
 
 	 <span id="timeline-selected-date">&nbsp;</span>
 	 <span>

--- a/static/css/browse/main.css
+++ b/static/css/browse/main.css
@@ -33,8 +33,11 @@ li#control-fullscreen {
 }
 
 #titlebar {
-    background: white;
-    display: flex;
+    /* background: rgba(255, 255, 255, 0.8); */
+    background: rgba(218, 112, 214, 0.8);  /* orchid */
+    /* display: flex;  will be changed to this on load */
+    color: white;
+    display: none;
     justify-content: space-between;
     padding-top: 0.4em;
     position: fixed;
@@ -49,6 +52,10 @@ li#control-fullscreen {
     padding-left: 0.5em;
 }
 
+#home a abbr {
+    color: white;
+}
+
 #timeline-selected-obs a {
     cursor: pointer;
     text-decoration: underline;  /* this is a "fake" link */
@@ -61,7 +68,9 @@ li#control-fullscreen {
 /* Location of the cross hair (to some approximation during slews) */
 
 div#location {
-    background: white;
+    /* background: rgba(255, 255, 255, 0.8); */
+    background: rgba(218, 112, 214, 0.8);  /* orchid */
+    color: white;
     display: none;
     padding: 0.2em;
     position: absolute;
@@ -75,23 +84,17 @@ div#location {
  */
 
 div.statusPane {
-    background: white;
+    background: rgba(255, 255, 255, 0.8);
     cursor: grab;
 
     /* if padding changes, need to change the margin-right/left
      * settings in controlElements */
-    padding-bottom: 0.5em;
+    padding-bottom: 0;
     padding-left: 0.5em;
     padding-right: 0.5em;
 
     position: absolute;
-}
 
-/* should get re-integrated into the list above, but leave out for now
- * (was broken out as was re-using the above settings for other panes
- *  but currently not).
- */
-div.statusPane {
     bottom: 2em;
     left: 2em;
     width: 25em;
@@ -105,6 +108,17 @@ div.scienceobs {
     overflow: auto;
     height: 15em;
 }
+
+/*
+ * Since the scienceobs class adds a large vertical height there is
+ * a difference in behaviour when the cal observation is shown compared
+ * to a science observation. This is an attempt to address this (relevant
+ * with the opaque title but solid main area code).
+ */
+div#observation p:last-child {
+    margin-bottom: -1em;
+}
+
 
 /* These two are only really needed if the content overflows vertically */
 
@@ -154,6 +168,7 @@ span.title {
 
 div.controlElements span.closable {
     display: flex;
+    order: 10;  /* display last */
 }
 
 .closable {
@@ -189,6 +204,25 @@ div.controlElements span.switchable {
     border-bottom: 1em solid #F55;
     border-left: 0.5em solid transparent;
     border-right: 0.5em solid transparent;
+}
+
+div.main {
+    background: white;
+
+    /*
+     * Expand to match div.controlElements so the background covers the
+     * whole area.
+     */
+    margin-left: -0.5em;
+    margin-right: -0.5em;
+
+    margin-bottom: -1em;  /* skyPane when expand details seems to need this */
+
+    /* reset this extra space */
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+
+    padding-top: 0.2em;  /* add a little bit of vertical space */
 }
 
 /*

--- a/static/css/browse/sky.css
+++ b/static/css/browse/sky.css
@@ -11,7 +11,7 @@ div#sky {
     margin-bottom: 0.5em;
     margin-left: auto;
     margin-right: auto;
-    margin-top: 0.5em;
+    /* margin-top: 0.5em; */
 
     /* width: 400px; */
 }
@@ -82,7 +82,7 @@ div#sky {
 }
 
 div.skyPane {
-    background: white;
+    background: rgba(255, 255, 255, 0.8);
 
     bottom: 2em;
     
@@ -90,7 +90,7 @@ div.skyPane {
 
     /* if padding changes, need to change the margin-right/left
      * settings in controlElements */
-    padding-bottom: 0.5em;
+    padding-bottom: 0;
     padding-left: 0.5em;
     padding-right: 0.5em;
 
@@ -104,14 +104,11 @@ div.skyPane {
 
 div.searchtype {
     font-weight: bold;
-    margin-top: 0.5em;
     text-align: center;
-    /* width: 400px; */ /* match div#sky */
 }
 
 p.searchinfo {
     margin-top: 0.5em;
-    /* width: 400px; */ /* match div#sky */
 }
 
 div.skyPane details {

--- a/static/js/browse/main.js
+++ b/static/js/browse/main.js
@@ -585,8 +585,8 @@ const main = (function() {
         showCurrentDate();
         setInterval(showCurrentDate, 10000);
 
-	// Set up the location field
-        setInterval(showLocation, 10000);
+	// Set up the location field; reset every 5 seconds
+        setInterval(showLocation, 5000);
 
 	// Display the control elements. Should probably be in a
 	// single structure to make this easier (and to ensure things
@@ -595,6 +595,17 @@ const main = (function() {
 	['control', 'location'].forEach((n) => {
 	    document.querySelector('#' + n).style.display = 'block';
 	});
+
+	// Make the titlebar visible (hopefully this is after the
+	// time/observation details are shown; we could make this
+	// a certainty, ish).
+	//
+	const titlebar = document.querySelector("#titlebar");
+	if (titlebar === null) {
+	    console.log('INTERNAL ERROR: #titlebar not found');
+	    return;
+	}
+	titlebar.style.display = "flex";
     }
 
 


### PR DESCRIPTION
Change to use more opaque text, including on the title bars of the observation details and sky pane, which ended up being more involved than originally planned.

There is some attempt to avoid "flashing" as the page loads and information starts getting set up, but it's not ideal.