### PR TITLE
browse: make the skyview draggable

### DIFF
--- a/app/Views/Record.hs
+++ b/app/Views/Record.hs
@@ -439,7 +439,7 @@ vowels = "aeiou"
 -- TODO: send HtmlContext to details display
 --
 -- Note: the information content now depends on the HtmlContext; in particular
---       the "related observatios" are not included with a Dynamic context.
+--       the "related observations" are not included with a Dynamic context.
 --
 targetInfo ::
   HtmlContext

--- a/static/css/browse/sky.css
+++ b/static/css/browse/sky.css
@@ -83,10 +83,9 @@ div#sky {
 
 div.skyPane {
     background: rgba(255, 255, 255, 0.8);
-
     bottom: 2em;
     
-    /* cursor: grab; */
+    cursor: grab;
 
     /* if padding changes, need to change the margin-right/left
      * settings in controlElements */

--- a/static/js/browse/main.js
+++ b/static/js/browse/main.js
@@ -249,10 +249,11 @@ const main = (function() {
     //
     // This also tells the WWT to jump to the location (on success)
     //
-    function makeStatusPane(obsid, rsp) {
+    function makeStatusPane(obsid, idVal, rsp) {
 
 	const pane = document.createElement('div');
 	pane.setAttribute('class', 'statusPane');
+	pane.setAttribute('id', idVal);
 
 	pane.draggable = true;
 	pane.addEventListener('dragstart', draggable.startDrag);
@@ -437,8 +438,7 @@ const main = (function() {
         }).done(function (rsp) {
 	    host.removeChild(spin);
 
-	    const pane = makeStatusPane(obsid, rsp);
-	    pane.setAttribute('id', idVal);
+	    const pane = makeStatusPane(obsid, idVal, rsp);
 	    host.appendChild(pane);
 
         }).fail(function(xhr, status, e) {
@@ -1669,6 +1669,10 @@ const main = (function() {
     //     dec    - decimal degrees
     //     expks  - exposure time in ks
     //
+    // We assume there will only ever be one skyPane created at a time,
+    // hence we can hard-code an id. An alternative is to send one in
+    // to this ruotine, but that is a *tad* more annoying to set up.
+    //
     function makeSky(host, data) {
 
 	/* delete any existing pane (rather than reusing it) */
@@ -1676,14 +1680,10 @@ const main = (function() {
 
 	const pane = document.createElement('div');
 	pane.setAttribute('class', 'skyPane');
+	pane.setAttribute('id', 'skypane-identifier');
 
-	// There appear to be issues making this draggable
-	// so disable for now
-	/***
 	pane.draggable = true;
-	pane.addEventListener('dragstart',
-			      event => draggable.startDrag(event));
-	***/
+	pane.addEventListener('dragstart', draggable.startDrag);
 
 	const controlElements = document.createElement('div');
 	controlElements.classList.add('controlElements');
@@ -1862,6 +1862,7 @@ const main = (function() {
 	    getWWT: () => wwt,
 	    getHost: getHost,
 
+	    // See app/API.hs for calls to this
 	    addSkyView: addSky,
 
 	    zoomIn : zoomIn,


### PR DESCRIPTION
The reason why it had not worked was because the skypane needed an id, which it didn't have.